### PR TITLE
Add GitHub Skills activity (closes #6)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub Certifications program. Perfect for college applications!",
+        "schedule": "Mondays and Fridays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
Adds the GitHub Skills activity to the activities list to address student requests from Issue #6.

## Changes
- Added "GitHub Skills" activity with details about the GitHub Certifications program
- Schedule: Mondays and Fridays, 3:30 PM - 4:30 PM
- Capacity: 25 students
- Initially empty participants list (open for registration)

## Closes
Fixes #6: 🚨 Missing Activity: GitHub Skills

## Testing
The activity is now available in the activities list and students can register for it through the existing signup endpoint.